### PR TITLE
Fix `tourGroup` not being set in localStorage and `handleFinishTour()` not closing modal on first call.

### DIFF
--- a/src/handlers/handleFinishTour.ts
+++ b/src/handlers/handleFinishTour.ts
@@ -15,6 +15,8 @@ async function handleFinishTour(this: TourGuideClient, exit : boolean = true, to
     if(this.options.completeOnFinish) {
         if (!localStorage.tg_tours_complete) {
             localStorage.tg_tours_complete = [tourGroup]
+            if (exit) await this.exit();
+            this.activeStep = 0;
             return
         }
         const storageTours = (localStorage.tg_tours_complete as string).split(',')

--- a/src/handlers/handleFinishTour.ts
+++ b/src/handlers/handleFinishTour.ts
@@ -15,8 +15,8 @@ async function handleFinishTour(this: TourGuideClient, exit : boolean = true, to
     if(this.options.completeOnFinish) {
         if (!localStorage.tg_tours_complete) {
             localStorage.tg_tours_complete = [tourGroup]
-            if (exit) await this.exit();
-            this.activeStep = 0;
+            if (exit) await this.exit()
+            this.activeStep = 0
             return
         }
         const storageTours = (localStorage.tg_tours_complete as string).split(',')

--- a/src/handlers/handleVisitStep.ts
+++ b/src/handlers/handleVisitStep.ts
@@ -20,7 +20,7 @@ async function handleVisitStep(this : TourGuideClient, stepIndex: "next" | "prev
          * Do completion if end of tour
          */
         if(stepIndex >= this.tourSteps.length){
-            await this.finishTour(true)
+            await this.finishTour(true, this.group);
             return
         }
 

--- a/src/handlers/handleVisitStep.ts
+++ b/src/handlers/handleVisitStep.ts
@@ -20,7 +20,7 @@ async function handleVisitStep(this : TourGuideClient, stepIndex: "next" | "prev
          * Do completion if end of tour
          */
         if(stepIndex >= this.tourSteps.length){
-            await this.finishTour(true, this.group);
+            await this.finishTour(true, this.group)
             return
         }
 


### PR DESCRIPTION
Fixes #8 and #9 

#9 can be demonstrated on https://tourguidejs.com/:
1. Open the storage tab in dev tools and ensure 'tg_tours_complete' does not exist in localStorage
2. Go through the tour and click 'Finish' - this will add 'tour' as the value for 'tg_tours_complete' in localStorage, but the tour modal will not close
3. Click 'Finish' a second time - now the tour modal will close

