### PR TITLE
fix import statement for type only imports

### DIFF
--- a/src/Tour.ts
+++ b/src/Tour.ts
@@ -10,14 +10,14 @@
  */
 
 // CORE
-import TourGuideOptions from "./core/options";
+import type TourGuideOptions from "./core/options";
 import {createTourGuideDialog} from "./core/dialog";
 import computeTourPositions from "./core/positioning";
 import {computeBackdropAttributes, createTourGuideBackdrop} from "./core/backdrop";
 import {handleOnAfterExit, handleOnAfterStepChange, handleOnBeforeExit, handleOnBeforeStepChange, handleOnFinish} from "./core/callbacks";
 import {clickOutsideHandler, handleDestroyListeners, handleInitListeners, keyPressHandler} from "./core/listeners";
 // Step Type
-import {TourGuideStep} from "./types/TourGuideStep";
+import type {TourGuideStep} from "./types/TourGuideStep";
 // HANDLERS
 import handleVisitStep, {handleVisitNextStep, handleVisitPrevStep} from "./handlers/handleVisitStep";
 import handleAddStep from "./handlers/handleAddStep";

--- a/src/core/backdrop.ts
+++ b/src/core/backdrop.ts
@@ -1,4 +1,4 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 
 /**
  * createTourGuideBackdrop

--- a/src/core/callbacks.ts
+++ b/src/core/callbacks.ts
@@ -1,4 +1,4 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 
 /**
  * handleOnFinish

--- a/src/core/dialog.ts
+++ b/src/core/dialog.ts
@@ -1,6 +1,6 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 import {computeDots, dotsWrapperHtmlString} from "./dots";
-import {arrow, autoPlacement, computePosition as fui_computePosition, offset, Placement, shift} from "@floating-ui/dom";
+import {arrow, autoPlacement, computePosition as fui_computePosition, offset, type Placement, shift} from "@floating-ui/dom";
 
 /**
  * createTourGuideDialog

--- a/src/core/dots.ts
+++ b/src/core/dots.ts
@@ -1,4 +1,4 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 
 /**
  * dotsWrapperHtmlString

--- a/src/core/listeners.ts
+++ b/src/core/listeners.ts
@@ -1,4 +1,4 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 
 /**
  * clickOutsideHandler

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -1,5 +1,5 @@
-import { AlignedPlacement, Side } from "@floating-ui/core"
-import { TourGuideStep } from "../types/TourGuideStep"
+import type { AlignedPlacement, Side } from "@floating-ui/core"
+import type { TourGuideStep } from "../types/TourGuideStep"
 
 /**
  * TourGuideOptions Type

--- a/src/core/positioning.ts
+++ b/src/core/positioning.ts
@@ -1,4 +1,4 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 import {computeBackdropPosition} from "./backdrop";
 import {computeDialogPosition} from "./dialog";
 

--- a/src/core/scrollTo.ts
+++ b/src/core/scrollTo.ts
@@ -1,4 +1,4 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 
 /**
  * scrollToTarget

--- a/src/core/steps.ts
+++ b/src/core/steps.ts
@@ -1,5 +1,5 @@
-import {TourGuideClient} from "../Tour";
-import {TourGuideStep} from "../types/TourGuideStep";
+import type {TourGuideClient} from "../Tour";
+import type {TourGuideStep} from "../types/TourGuideStep";
 /**
  * computeTourSteps
  * @param tgInstance

--- a/src/handlers/handleAddStep.ts
+++ b/src/handlers/handleAddStep.ts
@@ -1,5 +1,5 @@
-import {TourGuideClient} from "../Tour";
-import {TourGuideStep} from "../types/TourGuideStep";
+import type {TourGuideClient} from "../Tour";
+import type {TourGuideStep} from "../types/TourGuideStep";
 import computeTourSteps from "../core/steps";
 import {updateDialogHtml} from "../core/dialog";
 import waitForElm from "../util/util_wait_for_element";

--- a/src/handlers/handleClose.ts
+++ b/src/handlers/handleClose.ts
@@ -1,4 +1,4 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 
 async function handleClose(this: TourGuideClient) {
 

--- a/src/handlers/handleFinishTour.ts
+++ b/src/handlers/handleFinishTour.ts
@@ -1,4 +1,4 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 
 /**
  * handleFinishTour

--- a/src/handlers/handleRefresh.ts
+++ b/src/handlers/handleRefresh.ts
@@ -1,4 +1,4 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 import computeTourSteps from "../core/steps";
 import {renderDialogHtml, updateDialogHtml} from "../core/dialog";
 import waitForElm from "../util/util_wait_for_element";

--- a/src/handlers/handleSetOptions.ts
+++ b/src/handlers/handleSetOptions.ts
@@ -1,5 +1,5 @@
-import {TourGuideClient} from "../Tour";
-import TourGuideOptions from "../core/options";
+import type {TourGuideClient} from "../Tour";
+import type TourGuideOptions from "../core/options";
 import {renderDialogHtml, updateDialogHtml} from "../core/dialog";
 import waitForElm from "../util/util_wait_for_element";
 

--- a/src/handlers/handleTourStart.ts
+++ b/src/handlers/handleTourStart.ts
@@ -1,4 +1,4 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 import waitForElm from "../util/util_wait_for_element";
 import computeTourSteps from "../core/steps";
 

--- a/src/handlers/handleVisitStep.ts
+++ b/src/handlers/handleVisitStep.ts
@@ -1,4 +1,4 @@
-import {TourGuideClient} from "../Tour";
+import type {TourGuideClient} from "../Tour";
 import {updateDialogHtml} from "../core/dialog";
 import scrollToTarget from "../core/scrollTo";
 

--- a/src/util/util_default_options.ts
+++ b/src/util/util_default_options.ts
@@ -1,4 +1,4 @@
-import TourGuideOptions from "../core/options";
+import type TourGuideOptions from "../core/options";
 
 const defaultOptions = {
     nextLabel: "Next",


### PR DESCRIPTION
Strict TS deems it an error to import a type without `import type`. For example:

```
Error: This import is never used as a value and must use 'import type' because 'importsNotUsedAsValues' is set to 'error'.
import type {TourGuideClient} from "../Tour";
import {TourGuideStep} from "../types/TourGuideStep";
```

So this PR changes all the places where that was just an `import` before so no longer throws any TS errors for people using the strict setting in their TSConfig.