### PR TITLE
fix strict ts types error when verbatimModuleSyntax

### DIFF
--- a/src/Tour.ts
+++ b/src/Tour.ts
@@ -10,7 +10,7 @@
  */
 
 // CORE
-import TourGuideOptions from "./core/options";
+import type {TourGuideOptions} from "./core/options";
 import {createTourGuideDialog} from "./core/dialog";
 import computeTourPositions from "./core/positioning";
 import {computeBackdropAttributes, createTourGuideBackdrop} from "./core/backdrop";

--- a/src/core/dialog.ts
+++ b/src/core/dialog.ts
@@ -1,6 +1,7 @@
 import {TourGuideClient} from "../Tour";
 import {computeDots, dotsWrapperHtmlString} from "./dots";
-import {arrow, autoPlacement, computePosition as fui_computePosition, offset, Placement, shift, MiddlewareData} from "@floating-ui/dom";
+import {arrow, autoPlacement, computePosition as fui_computePosition, offset, shift} from "@floating-ui/dom";
+import type {Placement, MiddlewareData} from "@floating-ui/dom";
 
 /**
  * createTourGuideDialog

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -1,10 +1,10 @@
-import { AlignedPlacement, Side } from "@floating-ui/core"
+import type { AlignedPlacement, Side } from "@floating-ui/core"
 import { TourGuideStep } from "../types/TourGuideStep"
 
 /**
  * TourGuideOptions Type
  */
-interface TourGuideOptions {
+export interface TourGuideOptions {
   autoScroll?: boolean // auto scroll to elements
   autoScrollSmooth?: boolean // auto scroll smooth
   autoScrollOffset?: number // Offset from edge for smooth scroll
@@ -37,5 +37,3 @@ interface TourGuideOptions {
   debug?: boolean // show console logging
   steps?: TourGuideStep[] // pre-define the tour steps
 }
-
-export default TourGuideOptions;

--- a/src/handlers/handleSetOptions.ts
+++ b/src/handlers/handleSetOptions.ts
@@ -1,5 +1,5 @@
 import {TourGuideClient} from "../Tour";
-import TourGuideOptions from "../core/options";
+import type {TourGuideOptions} from "../core/options";
 import {renderDialogHtml, updateDialogHtml} from "../core/dialog";
 import waitForElm from "../util/util_wait_for_element";
 

--- a/src/util/util_default_options.ts
+++ b/src/util/util_default_options.ts
@@ -1,4 +1,4 @@
-import TourGuideOptions from "../core/options";
+import type {TourGuideOptions} from "../core/options";
 
 const defaultOptions = {
     nextLabel: "Next",


### PR DESCRIPTION
fixes strict TS setting type errors coming from not explicitly marking imports as a type. 
![Screenshot 2024-02-17 at 10 10 59 AM](https://github.com/sjmc11/tourguide-js/assets/40811287/20827994-7d2f-46fb-ba1e-3996dce4829e)

