### PR TITLE
Don't set target element for steps unless it is found

### DIFF
--- a/src/core/steps.ts
+++ b/src/core/steps.ts
@@ -14,7 +14,6 @@ async function computeTourSteps(tgInstance : TourGuideClient){
         // Compute targets to HTML element and Body if not set
         if(tgInstance.options.steps && tgInstance.options.steps.length) {
             computedSteps = tgInstance.options.steps.map((t:TourGuideStep)=>{
-                console.log('mapping', t.target)
                 // If target is string, query element by selector
                 if(typeof t.target === "string"){
                     const targetElement = document.querySelector(t.target)

--- a/src/core/steps.ts
+++ b/src/core/steps.ts
@@ -6,7 +6,6 @@ import {TourGuideStep} from "../types/TourGuideStep";
  */
 async function computeTourSteps(tgInstance : TourGuideClient){
     return new Promise(async (resolve, reject) => {
-
         let computedSteps : TourGuideStep[] = []
 
         /**
@@ -15,8 +14,12 @@ async function computeTourSteps(tgInstance : TourGuideClient){
         // Compute targets to HTML element and Body if not set
         if(tgInstance.options.steps && tgInstance.options.steps.length) {
             computedSteps = tgInstance.options.steps.map((t:TourGuideStep)=>{
+                console.log('mapping', t.target)
                 // If target is string, query element by selector
-                if(typeof t.target === "string") t.target = document.querySelector(t.target)
+                if(typeof t.target === "string"){
+                    const targetElement = document.querySelector(t.target)
+                    if (targetElement) t.target = targetElement
+                }
                 // If target is empty, set target to body
                 if(!t.target) t.target = document.body
                 return t


### PR DESCRIPTION
This is a PR that serves as a workaround/fix for https://github.com/sjmc11/tourguide-js/issues/12.

Right now it is possible to navigate to a different view or render an element before the next step is loaded via the `onBeforeStepChange` event. However, when a new element is rendered, it cannot be targeted even if `refresh()` or `updatePositions()`. This happens because the target element is undefined (because it does not exist yet) when the steps are initially computed, and recomputing them through a refresh does not work because the target is replaced by the `undefined` value on the first compute.

By simply not setting the target if the element cannot be found during compute, this can be avoided and new elements can easily be targeted after calling `refresh()`.